### PR TITLE
Fix getItemPublished function

### DIFF
--- a/parsers/atomv1.js
+++ b/parsers/atomv1.js
@@ -159,7 +159,7 @@ function getItemPublished(node) {
   var pub = utils.getElementTextContent(node, 'updated');
 
   if(pub === '' || pub === undefined){
-    utils.getElementTextContent(node, 'published');
+    pub = utils.getElementTextContent(node, 'published');
   }
 
   return pub;

--- a/test/samples/atomv1-no-updated.js
+++ b/test/samples/atomv1-no-updated.js
@@ -1,0 +1,39 @@
+exports.feed = `
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+	<title>ATOM title</title>
+  <subtitle>A sample ATOM feed</subtitle>
+  <logo>https://b.thumbs.redditmedia.com/ntr1FkBiO3nk4t4Vgy5GXoPQ_j2hirENH9iT8rXNf8M.png</logo>
+  <generator uri="http://jekyllrb.com" version="3.1.2">Jekyll</generator>
+  <link href="http://bakery-store.example.com/" rel="alternate" type="text/html" />
+  <updated>2016-05-13T16:22:08+12:00</updated>
+  <id>http://bakery-store.example.com/</id>
+  <entry>
+    <title>Where Did The Cookie Come From</title>
+    <link href="http://bakery-store.example.com/information/2016/01/02/where-did-the-cookie-come-from.html" rel="alternate" type="text/html" title="Where Did The Cookie Come From" />
+    <link href="https://www.example.com/audio.mp3" rel="enclosure" type="audio/mpeg" length="1234" />
+    <published>2016-01-02T00:00:00+13:00</published>
+    <id>http://bakery-store.example.com/information/2016/01/02/where-did-the-cookie-come-from</id>
+    <icon>https://b.thumbs.redditmedia.com/ntr1FkBiO3nk4t4Vgy5GXoPQ_j2hirENH9iT8rXNf8.png</icon>
+    <content type="html" xml:base="http://bakery-store.example.com/information/2016/01/02/where-did-the-cookie-come-from.html">&lt;p&gt;The chocolate chip cookie was invented by Ruth Graves Wakefield. She owned the Toll House Inn, in Whitman, Massachusetts, a very popular restaurant that featured home cooking in the 1930s. Her cookbook, Toll House Tried and True Recipes, was first published in 1936 by M. Barrows &amp;amp; Company, New York. The 1938 edition of the cookbook was the first to include the recipe “Toll House Chocolate Crunch Cookie” which rapidly became a favorite cookie in American homes.&lt;/p&gt;
+
+&lt;p&gt;Source / Read more &lt;a href=&quot;https://en.wikipedia.org/wiki/Chocolate_chip_cookie&quot;&gt;Wikipedia&lt;/a&gt;&lt;/p&gt;
+    </content>
+    <category term="Information" />
+    <summary>The chocolate chip cookie was invented by Ruth Graves Wakefield.</summary>
+  </entry>
+  <entry>
+    <title>What Is Sour Dough</title>
+    <link href="http://bakery-store.example.com/information/2016/01/01/what-is-sour-dough.html" rel="alternate" type="text/html" title="What Is Sour Dough" />
+    <published>2016-01-01T00:00:00+13:00</published>
+    <updated>2016-01-01T00:00:00+13:00</updated>
+    <id>http://bakery-store.example.com/information/2016/01/01/what-is-sour-dough</id>
+    <content type="html" xml:base="http://bakery-store.example.com/information/2016/01/01/what-is-sour-dough.html">&lt;p&gt;Sourdough bread is made by the fermentation of dough using naturally-occurring lactobacilli and yeast. Sourdough bread has a mildly sour taste not present in most breads made with baker’s yeast and better inherent keeping qualities than other breads, due to the lactic acid produced by the lactobacilli.&lt;/p&gt;
+
+&lt;p&gt;Source / Read more &lt;a href=&quot;https://en.wikipedia.org/wiki/Sourdough&quot;&gt;Wikipedia&lt;/a&gt;&lt;/p&gt;
+    </content>
+    <category term="Information" />
+    <summary>Sourdough bread is made by the fermentation of dough using naturally-occurring lactobacilli and yeast. Sourdough bread has a mildly sour taste not present in most breads made with baker’s yeast and better inherent keeping qualities than other breads, due to the lactic acid produced by the lactobacilli.</summary>
+  </entry>
+</feed>
+`;

--- a/test/test-parser-atomv1.js
+++ b/test/test-parser-atomv1.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 var atomv1 = require('./samples/atomv1');
 var atomv1WithItunes = require('./samples/atomv1-with-itunes');
+var atomv1NoUpdated = require('./samples/atomv1-no-updated');
 var huffpost = require('./samples/huffpost');
 var rssParser = require('../index');
 
@@ -27,6 +28,7 @@ describe('when parse ATOM', function() {
           assert.equal(result.items[0].enclosures[0].length, '1234');
           assert.equal(result.items[0].description, 'The chocolate chip cookie was invented by Ruth Graves Wakefield.');
           assert.equal(result.items[1].title, 'What Is Sour Dough');
+          assert.equal(result.items[0].published, '2016-01-02T00:00:00+13:00');
         });
     });
   });
@@ -85,6 +87,15 @@ describe('when parse ATOM', function() {
       return rssParser.parse(huffpost.feed)
         .then((result) => {
           assert.notEqual(result, undefined);
+        });
+    });
+  });
+
+  describe('when item has no updated element', function() {
+    it('should return published element', function() {
+      return rssParser.parse(atomv1NoUpdated.feed)
+        .then((result) => {
+          assert.equal(result.items[0].published, '2016-01-02T00:00:00+13:00');
         });
     });
   });


### PR DESCRIPTION
When an item does not have "updated" field, you're trying to get "published" field but you're not returning it.