### PR TITLE
Run npm test on (CI) continuous integration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,9 @@ name: run npm tests.
 
 on:
   push:
-    branches: [run-tests-on-ci]
+    branches: [master]
   pull_request:
-    branches: [run-tests-on-ci]
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: run npm tests.
+
+on:
+  push:
+    branches: [run-tests-on-ci]
+  pull_request:
+    branches: [run-tests-on-ci]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install modules
+        run: npm ci
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install modules
         run: npm ci
       - name: Run tests


### PR DESCRIPTION
Hey @jameslawler I made a GitHub Actions workflow that will run `npm test` on the master branch for pushes and will also run for pull request's (PR's) Note: you might need to approve it to run.

Cheers.